### PR TITLE
Fixed wake command using device address not 0x00 as address

### DIFF
--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -147,7 +147,13 @@ impl Ecc {
     }
 
     fn send_wake(&mut self) {
-        let _ = self.send_buf(&[0]);
+        let write_msg = i2c_linux::Message::Write {
+            address: 0,
+            data: &[0],
+            flags: Default::default(),
+        };
+
+        let _ = self.i2c.i2c_transfer(&mut [write_msg]);
     }
 
     fn send_sleep(&mut self) {


### PR DESCRIPTION
Using the ATECC608A chip and using this library in conjunction with gateway-mfr-rs, all read / write attempts were met with timeout errors indicating that the communication was failing. The root of the issue seems to come from the send_wake function in ecc.rs using the send_buf method which defaults the address to be the given ECC i2c address.

To remedy this issue, instead of calling send_buf in send_wake, we should directly write to i2c and manually specify the address and data content. 

This issue could extend to the send_sleep method, but I cannot see any requirement / spec for a sleep command in the ECC608 chip documentation. Hence I am leaving it unchanged to limit causing further bugs.