### PR TITLE
Adding SWI interface support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,36 @@
 version = 3
 
 [[package]]
+name = "CoreFoundation-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0e9889e6db118d49d88d84728d0e964d973a5680befb5f85f55141beea5c20b"
+dependencies = [
+ "libc",
+ "mach 0.1.2",
+]
+
+[[package]]
+name = "IOKit-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99696c398cbaf669d2368076bdb3d627fb0ce51a26899d7c61228c5c0af3bf4a"
+dependencies = [
+ "CoreFoundation-sys",
+ "libc",
+ "mach 0.1.2",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bitfield"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,6 +64,18 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "cc"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -68,6 +110,7 @@ dependencies = [
  "i2c-linux",
  "serde",
  "serde_derive",
+ "serialport",
  "sha2",
  "thiserror",
 ]
@@ -111,6 +154,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
 
 [[package]]
+name = "mach"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd13ee2dd61cc82833ba05ade5a30bb3d63f7ced605ef827063c63078302de9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "nix"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0eaf8df8bab402257e0a5c17a254e4cc1f72a93588a1ddfb5d356c801aa7cb"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 0.1.10",
+ "libc",
+ "void",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +213,23 @@ checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "resize-slice"
@@ -161,13 +258,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serialport"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cd7c0f22290ee2c01457009fa6fc1cae4153d5608a924e5dc423babc2c655"
+dependencies = [
+ "CoreFoundation-sys",
+ "IOKit-sys",
+ "bitflags",
+ "cfg-if 0.1.10",
+ "mach 0.2.3",
+ "nix",
+ "regex",
+ "winapi",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -227,3 +340,31 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 
 [dependencies]
 i2c-linux = "0"
+serialport = { version = "4.0.1", default-features = false}
 sha2 = "0"
 bytes = "1"
 bitfield = "0"

--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -5,14 +5,23 @@ use crate::{
 };
 use bytes::{BufMut, Bytes, BytesMut};
 use i2c_linux::{I2c, ReadFlags};
+use serialport::SerialPort;
 use sha2::{Digest, Sha256};
 use std::{fs::File, thread, time::Duration};
 
 pub use crate::command::KeyType;
 
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub(crate) enum EccIface {
+    EccI2CIface = 0,                         //Standard I2C interface
+    EccSWIIface = 1,                         //SWI Iface over UART
+}
+
 pub struct Ecc {
-    i2c: I2c<File>,
-    address: u16,
+    i2c: Option<I2c<File>>,                  //Field changed to optional to support other protocols
+    address: u16,                            //To keep backward compatibility, the address field is used to decide on the protocol. Address 0 reserved for SWI
+    port: Option<Box<dyn SerialPort>>,       //Used to implement SWI over UART, or other direct uart interfaces
+    iface: EccIface,                         //Should be set on instance creation to define the selected protocol. Parsed from address in from_path
 }
 
 pub const MAX_SLOT: u8 = 15;
@@ -21,11 +30,49 @@ pub(crate) const RECV_RETRIES: u8 = 2;
 pub(crate) const RECV_RETRY_WAIT: Duration = Duration::from_millis(50);
 pub(crate) const CMD_RETRIES: u8 = 10;
 
+pub(crate) const SWI_IOFLAG_CMD: u8   = 0x77;          //Header flag to be sent before command in case of SWI
+pub(crate) const SWI_IOFLAG_TX: u8    = 0x88;          //Transmit flag used to tell the device to start transmitting its response
+pub(crate) const SWI_IOFLAG_WAKE: u8  = 0x00;          //Upon receipt of a wake flag, the device wakes up from sleep or idle modes
+pub(crate) const SWI_IOFLAG_SLEEP: u8 = 0xCC;          //Upon receipt of a sleep flag, the device enters the low-power sleep mode
+
+pub(crate) const SWI_DEFAULT_BAUDRATE: u32  = 230_400;    //Default baud rate used for communication
+pub(crate) const SWI_WAKE_BAUDRATE: u32     = 115_200;    //Baudrate used only for wake to simulate a long low level pulse
+pub(crate) const SWI_SERIAL_TIMEOUT_MS: u64 = 500;        //Default timeout on serial bus
+pub(crate) const SWI_BYTE_AS_BIT_ONE: u8    = 0x7F;       //In SWI each bit is transmitted as UART byte, bit 1 is sent as 0x7F
+pub(crate) const SWI_BYTE_AS_BIT_ZERO: u8   = 0x7D;       //In SWI each bit is transmitted as UART byte, bit 0 is sent as 0x7D
+
 impl Ecc {
     pub fn from_path(path: &str, address: u16) -> Result<Self> {
+        if address != 0 {                            //Address 0 is reserved for SWI, I2C being the only other option for this implementation
         let mut i2c = I2c::from_path(path)?;
         i2c.smbus_set_slave_address(address, false)?;
-        Ok(Self { i2c, address })
+            Ok(Self {
+                i2c: Some(i2c),
+                address,
+                port: None,
+                iface: EccIface::EccI2CIface,
+            })
+        } else {
+            if let Ok(port) = serialport::new(path, SWI_DEFAULT_BAUDRATE) //From ECC datasheet, The UART should be set to seven data bits, no parity and one Stop bit.
+                .data_bits(serialport::DataBits::Seven)
+                .parity(serialport::Parity::None)
+                .stop_bits(serialport::StopBits::One)
+                .timeout(Duration::from_millis(SWI_SERIAL_TIMEOUT_MS))
+                .open()
+            {
+                Ok(Self {
+                    i2c: None,
+                    address,
+                    port: Some(port),
+                    iface: EccIface::EccSWIIface,
+                })
+            } else {
+                Err(Error::IoError(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "Unable to open serial port",
+                )))
+            }
+        }
     }
 
     pub fn get_info(&mut self) -> Result<Bytes> {
@@ -155,11 +202,30 @@ impl Ecc {
     }
 
     fn send_wake(&mut self) {
-        let _ = self.send_buf(0, &[0]);
+        match self.iface {
+            EccIface::EccI2CIface => {
+                let _ = self.send_buf(self.address, &[0]);
+            }
+            EccIface::EccSWIIface => {
+                let mut rx_buf: Vec<u8> = vec![0; 1];
+
+                let _ = self.port.as_mut().unwrap().set_baud_rate(SWI_WAKE_BAUDRATE);     //Wake is a long low pulse, reduce baudrate to emulate it
+                let _ = self.port.as_mut().unwrap().write(&[SWI_IOFLAG_WAKE]);            //No need to encode bits for wake, just send
+                let _ = self.port.as_mut().unwrap().read(rx_buf.as_mut_slice());          //Dummy read back
+                let _ = self.port.as_mut().unwrap().set_baud_rate(SWI_DEFAULT_BAUDRATE);  //Reset baud rate to default value
+            }
+        }
     }
 
     fn send_sleep(&mut self) {
+        match self.iface {
+            EccIface::EccI2CIface => {
         let _ = self.send_buf(self.address, &[1]);
+    }
+            EccIface::EccSWIIface => {
+                let _ = self.send_buf(self.address, &[SWI_IOFLAG_SLEEP]);
+            }
+        }
     }
 
     pub(crate) fn send_command(&mut self, command: &EccCommand) -> Result<Bytes> {
@@ -177,6 +243,15 @@ impl Ecc {
             buf.clear();
             command.bytes_into(&mut buf);
 
+            match self.iface {                  //CMD byte is different between SWI and I2C
+                EccIface::EccI2CIface => {
+                    buf[0] = 0x03;
+                }
+                EccIface::EccSWIIface => {
+                    buf[0] = SWI_IOFLAG_CMD;
+                }
+            }
+
             self.send_wake();
             thread::sleep(WAKE_DELAY);
 
@@ -192,6 +267,7 @@ impl Ecc {
             if sleep {
                 self.send_sleep();
             }
+
             match response {
                 EccResponse::Data(bytes) => return Ok(bytes),
                 EccResponse::Error(err) if err.is_recoverable() && retry < retries => {
@@ -209,43 +285,131 @@ impl Ecc {
         self.recv_buf(buf)
     }
 
+    pub(crate) fn swi_bits_to_bytes(&mut self, buf: &[u8]) -> Vec<u8> {
+        let mut vec = Vec::new();
+        for n in 0..buf.len() {
+            for bit_mask in 0..8 {
+                if buf[n] & (1 << bit_mask) == 0 {
+                    vec.push(SWI_BYTE_AS_BIT_ZERO);
+                } else {
+                    vec.push(SWI_BYTE_AS_BIT_ONE);
+                }
+            }
+        }
+        vec
+    }
+
     pub(crate) fn send_buf(&mut self, address: u16, buf: &[u8]) -> Result {
+        match self.iface {
+            EccIface::EccI2CIface => {
         let write_msg = i2c_linux::Message::Write {
             address,
             data: buf,
             flags: Default::default(),
         };
+                self.i2c.as_mut().unwrap().i2c_transfer(&mut [write_msg])?;
+            }
 
-        self.i2c.i2c_transfer(&mut [write_msg])?;
+            EccIface::EccSWIIface => {
+                let bytes = &self.swi_bits_to_bytes(buf);        //In SWI mode, each bit is sent as byte. Transform bits to bytes before sending.
+
+                for i in 0..bytes.len() {                        //Send one byte at a time and make sure the byte is transferred succesfully by comparing it to RX byte.
+                    let mut rx_buf: Vec<u8> = vec![0; 1];
+                    self.port.as_mut().unwrap().write(&[bytes[i]])?;
+                    self.port.as_mut().unwrap().read(rx_buf.as_mut_slice())?;
+                    if rx_buf[0] != bytes[i] {
+                        return Err(Error::timeout());
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn swi_receive(&mut self, buf: &mut [u8]) -> Result {
+        for byte_idx in 0..buf.len() {
+            let mut decoded_byte = 0;
+            let mut bit_mask: u8 = 1;
+
+            while bit_mask != 0 {
+                let mut rx_byte = [0; 1];
+
+                if let Ok(_rx_count) = self.port.as_mut().unwrap().read(&mut rx_byte) {
+                    if (rx_byte[0] ^ SWI_BYTE_AS_BIT_ONE) < 2 {
+                        decoded_byte |= bit_mask;
+                    }
+                } else {
+                    return Err(Error::timeout());
+                }
+                bit_mask = bit_mask << 1;
+            }
+
+            buf[byte_idx] = decoded_byte;
+        }
         Ok(())
     }
 
     pub(crate) fn recv_buf(&mut self, buf: &mut BytesMut) -> Result {
-        unsafe { buf.set_len(1) };
-        buf[0] = 0xff;
-        for _retry in 0..RECV_RETRIES {
-            let msg = i2c_linux::Message::Read {
-                address: self.address,
-                data: &mut buf[0..1],
-                flags: Default::default(),
-            };
-            if let Err(_err) = self.i2c.i2c_transfer(&mut [msg]) {
-            } else {
-                break;
+        match self.iface {
+            EccIface::EccI2CIface => {
+                unsafe { buf.set_len(1) };
+                buf[0] = 0xff;
+                for _retry in 0..RECV_RETRIES {
+                    let msg = i2c_linux::Message::Read {
+                        address: self.address,
+                        data: &mut buf[0..1],
+                        flags: Default::default(),
+                    };
+                    
+                    if let Err(_err) = self.i2c.as_mut().unwrap().i2c_transfer(&mut [msg]) {
+                    } else {
+                        break;
+                    }
+                    thread::sleep(RECV_RETRY_WAIT);
+                }
+
+                let count = buf[0] as usize;
+                if count == 0xff {
+                    return Err(Error::timeout());
+                }
+
+                unsafe { buf.set_len(count) };
+                let read_msg = i2c_linux::Message::Read {
+                    address: self.address,
+                    data: &mut buf[1..count],
+                    flags: ReadFlags::NO_START,
+                };
+                self.i2c.as_mut().unwrap().i2c_transfer(&mut [read_msg])?;
             }
-            thread::sleep(RECV_RETRY_WAIT);
+
+            EccIface::EccSWIIface => {
+
+                if let Err(_err) = self.port.as_mut().unwrap().set_baud_rate(SWI_DEFAULT_BAUDRATE)
+                {
+                    return Err(Error::timeout());
+                }
+                unsafe { buf.set_len(1) };
+                buf[0] = 0xff;
+                for _retry in 0..RECV_RETRIES {
+                    self.send_buf(self.address, &[SWI_IOFLAG_TX])?;
+                    if let Err(_err) = self.swi_receive(&mut buf[0..1]) {
+                    } else {
+                        break;
+                    }
+                    thread::sleep(RECV_RETRY_WAIT);
+                }
+                let count = buf[0] as usize;
+                if count == 0xff {
+                    return Err(Error::timeout());
+                }
+                unsafe { buf.set_len(count) };
+                if let Err(_err) = self.swi_receive(&mut buf[1..count]) {
+                    return Err(Error::timeout());
+                }
+            }
         }
-        let count = buf[0] as usize;
-        if count == 0xff {
-            return Err(Error::timeout());
-        }
-        unsafe { buf.set_len(count) };
-        let read_msg = i2c_linux::Message::Read {
-            address: self.address,
-            data: &mut buf[1..count],
-            flags: ReadFlags::NO_START,
-        };
-        self.i2c.i2c_transfer(&mut [read_msg])?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
The reason of this pull request is to add support for ECC608 over SWI. The I2C variant for ECC608 seem to be running out of stock everywhere. This was our main motivation for enabling the ECC608 via SWI. We are hoping that this pull request will serve other people in the community to mitigate these inventory problems.

While working on this code we wanted to achieve 2 objectives:
- Make sure any code changes related to SWI are limited to this library and do not require changes in the other repositories making use of this one (gateway-mfr-rs, gateway-rs, helium-crypto-rs...)
- For manufacturing reasons, the switch between I2C and SWI needs to be done on runtime. We don't want to create separate binaries for each variant. For example changes settings.toml for gateway-rs should be enough to change between I2C and SWI.

Based on the above we expanded the code to add support for SWI. To achieve the above objective, we elected to reserve I2C address 0 to signal that the user wants to use SWI instead of I2C. When the library is called with address 0, it internally switches to SWI over serial mode. The rest of the logic flow should be transparent. The code is based on the microchip Crypto

Major changes:
- Add serialport to dependencies
- Reserve address 0 for SWI
- Logic to encode/decode bytes before sending and receiving over serial (required for SWI emulation over serial)
- Change the Command IO Flag from 0x03 to 0x77 when using SWI

Tests:
-  Compile gateway-mfr-rs with this branch -> Commands are working fine for both I2C and SWI (info, key, test, provision...)
- Compile gateway-mfr with this branch -> Make a change in settings.toml to provide the path for the serial port (instead of I2C) with address (port in the url) set to 0, deployed to our custom hardware and appears to be working as expected.

Example settings.toml for SWI (only relevant part)
`keypair = "ecc://ttymxc4:0/&slot=0"`

For the future, it would be good to create a HAL layer in the library with support for different interfaces. 
