### PR TITLE
read atecc response at once

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -297,6 +297,7 @@ fn crc(src: &[u8]) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::constants::ATCA_CMD_SIZE_MAX;
 
     #[test]
     fn info() {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,6 +13,7 @@ pub(crate) const CMD_STATUS_BYTE_WATCHDOG: u8 = 0xEE;
 pub(crate) const CMD_STATUS_BYTE_COMM: u8 = 0xFF;
 
 pub(crate) const ATCA_RSP_SIZE_MIN: u8 = 4;
+pub(crate) const ATCA_RSP_SIZE_MAX: u8 = 75;
 
 pub(crate) const ATCA_SWI_TRANSMIT_FLAG: u8 = 0x88;
 pub(crate) const ATCA_SWI_SLEEP_FLAG: u8 = 0xCC;

--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -184,9 +184,7 @@ impl Ecc {
             }
             match response {
                 EccResponse::Data(bytes) => return Ok(bytes),
-                EccResponse::Error(err) if err.is_recoverable() && retry < retries => {
-                    continue;
-                }
+                EccResponse::Error(err) if err.is_recoverable() && retry < retries => continue,
                 EccResponse::Error(err) => return Err(Error::ecc(err)),
             }
         }


### PR DESCRIPTION
@madninja as discussed.

`ATCA_CMD_SIZE_MAX` comes from here: https://github.com/MicrochipTech/cryptoauthlib/blob/2dc8384e752f3f9154019b1af1bb8734d61e9f9f/lib/calib/calib_command.h#L237

You mentioned that a maker got 115 long responses. Not sure where they can come from but if that is the case this variable needs to be updated.

I have tested it with the `gateway-mfr-rs`.