### PR TITLE
command: param2 must be converted to big endian when passed as u16

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -231,7 +231,7 @@ impl EccCommand {
                 put_cmd!(bytes, ATCA_SIGN, u8::from(param1), (*key_slot as u16) << 8);
             }
             Self::Ecdh { x, y, key_slot } => {
-                put_cmd!(bytes, ATCA_ECDH, 0, *key_slot as u16);
+                put_cmd!(bytes, ATCA_ECDH, 0, (*key_slot as u16) << 8);
                 bytes.extend_from_slice(x);
                 bytes.extend_from_slice(y)
             }


### PR DESCRIPTION
put_cmd macro takes an u16 as param2 argument which need to be in big endian. 

While this causes no trouble when this parameter is field from Address object (bitfield), this is problematic when param2 is an u16 like slot_id. 

This path convert param2 to big endian when required.