### PR TITLE
Remove unnecessary "Random" command when signing.

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -2,7 +2,7 @@ use crate::{Error, Result};
 use bitfield::bitfield;
 use std::{fmt, str::FromStr};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Zone {
     Data,
     Config,
@@ -29,7 +29,7 @@ impl fmt::Display for Zone {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DataBuffer {
     TempKey,
     MessageDigest,
@@ -57,7 +57,7 @@ impl From<u8> for DataBuffer {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Address {
     Otp(OffsetAddress),
     Config(OffsetAddress),
@@ -65,7 +65,7 @@ pub enum Address {
 }
 
 bitfield! {
-    #[derive(PartialEq, Clone)]
+    #[derive(PartialEq, Eq, Clone)]
     pub struct OffsetAddress(u16);
     impl Debug;
     u8, offset, set_offset: 10, 8;
@@ -73,7 +73,7 @@ bitfield! {
 }
 
 bitfield! {
-    #[derive(PartialEq, Clone)]
+    #[derive(PartialEq, Clone, Eq)]
     pub struct DataAddress(u16);
     impl Debug;
     u8, block, set_block: 3, 0;

--- a/src/command.rs
+++ b/src/command.rs
@@ -10,7 +10,7 @@ use crate::{
 use bitfield::bitfield;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum KeyType {
     Public,
     Private,
@@ -25,7 +25,7 @@ impl From<&KeyType> for u8 {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum EccCommand {
     Info,
     GenKey { key_type: KeyType, slot: u8 },
@@ -82,7 +82,7 @@ impl From<SignParam> for u8 {
 }
 
 bitfield! {
-    #[derive(PartialEq)]
+    #[derive(PartialEq, Eq)]
     pub struct LockParam(u8);
     impl Debug;
     u8, zone, set_zone: 1, 0;
@@ -96,7 +96,7 @@ impl From<LockParam> for u8 {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum EccError {
     /// Command was properly received but the length, command opcode, or
     /// parameters are illegal regardless of the state (volatile and/or EEPROM
@@ -128,7 +128,7 @@ pub enum EccError {
     Unknown(u8),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum EccResponse {
     Error(EccError),
     Data(Bytes),

--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -111,7 +111,6 @@ impl Ecc {
     }
 
     pub fn sign(&mut self, key_slot: u8, data: &[u8]) -> Result<Bytes> {
-        let _ = self.send_command_retries(&EccCommand::random(), false, 1)?;
         let digest = Sha256::digest(data);
         let _ = self.send_command_retries(
             &EccCommand::nonce(DataBuffer::MessageDigest, Bytes::copy_from_slice(&digest)),

--- a/src/key_config.rs
+++ b/src/key_config.rs
@@ -2,7 +2,7 @@ use bitfield::bitfield;
 use bytes::Buf;
 use serde_derive::Serialize;
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum KeyConfigType {
     Ecc,
@@ -35,7 +35,7 @@ impl From<&[u8]> for KeyConfig {
 }
 
 bitfield! {
-    #[derive(PartialEq)]
+    #[derive(PartialEq, Eq)]
     pub struct KeyConfig(u16);
     impl Debug;
 

--- a/src/slot_config.rs
+++ b/src/slot_config.rs
@@ -35,7 +35,7 @@ impl Default for ReadKey {
 
 /// Write cofiguration from the write_config slot bits for a given command. The
 /// interpretation of the write_config bits differs based on the command used.
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum WriteConfig {
     Write(_WriteConfig),
@@ -44,7 +44,7 @@ pub enum WriteConfig {
     PrivWrite(PrivWriteConfig),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum WriteCommand {
     Write,
     DeriveKey,
@@ -80,7 +80,7 @@ impl Default for WriteConfig {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum _WriteConfig {
     /// Clear text writes are always permitted on this slot. Slots set to
@@ -125,7 +125,7 @@ impl From<_WriteConfig> for u8 {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum DeriveKeyConfig {
     ///  DeriveKey command can be run with/without authorizing MAC. Source Key:
@@ -163,7 +163,7 @@ impl From<DeriveKeyConfig> for u8 {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum GenKeyConfig {
     /// GenKey may not be used to write random keys into this slot.
@@ -190,7 +190,7 @@ impl From<GenKeyConfig> for u8 {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum PrivWriteConfig {
     /// PrivWrite will return an error if the target key slot has this value.
@@ -220,7 +220,7 @@ impl From<PrivWriteConfig> for u8 {
 }
 
 bitfield! {
-    #[derive(PartialEq)]
+    #[derive(PartialEq, Eq)]
     pub struct SlotConfig(u16);
     impl Debug;
     pub secret, set_secret: 15;


### PR DESCRIPTION
It is not neccessary to invoke the "GenRandom" command before requesting an ECDSA signature. This command does not generate the nonce (random value "k") that is required for ECDSA -- that is performed internally by the ECC508/ECC608 and always has been.

By removing this unnecessary command it should be possible to generate signatures in less time than before.