### PR TITLE
sending sleep command also when the error is unrecoverable

### DIFF
--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -272,15 +272,7 @@ impl Ecc {
                 self.transport.send_wake(wake_delay)?;
             }
 
-            if let Err(_err) = self.transport.send_recv_buf(delay, &mut buf) {
-                if retry == retries {
-                    // Sleep the chip to clear the SRAM when the maximum error retries have been exhausted
-                    self.transport.send_sleep();
-                    break;
-                } else {
-                    continue;
-                }
-            }
+            self.transport.send_recv_buf(delay, &mut buf);
 
             let response = EccResponse::from_bytes(&buf[..])?;
             

--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -284,11 +284,14 @@ impl Ecc {
             }
 
             let response = EccResponse::from_bytes(&buf[..])?;
-            if idle {
-                self.transport.send_idle();
-            }
+            
             match response {
-                EccResponse::Data(bytes) => return Ok(bytes),
+                EccResponse::Data(bytes) => {
+                    if idle && !should_sleep {
+                        self.transport.send_idle();
+                    }
+                    return Ok(bytes)
+                },
                 EccResponse::Error(err) if err.is_recoverable() && retry < retries => continue,
                 EccResponse::Error(err) => {
                     should_sleep = true; // Set the flag to send a sleep command

--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -302,6 +302,7 @@ impl Ecc {
 
         if should_sleep {
         self.transport.send_sleep(); // Send the sleep command
+        should_sleep = false;
         }
         
         Err(Error::timeout())

--- a/src/ecc.rs
+++ b/src/ecc.rs
@@ -275,16 +275,16 @@ impl Ecc {
             if let Err(_err) = self.transport.send_recv_buf(delay, &mut buf) {
                 continue;
             }
-            
+
             let response = EccResponse::from_bytes(&buf[..])?;
-            
+
             match response {
                 EccResponse::Data(bytes) => {
                     if idle {
                         self.transport.send_idle();
                     }
-                    return Ok(bytes)
-                },
+                    return Ok(bytes);
+                }
                 EccResponse::Error(err) if err.is_recoverable() && retry < retries => continue,
                 EccResponse::Error(err) => {
                     self.transport.send_sleep();


### PR DESCRIPTION
The chip will be occasionally stuck in a state where it will not respond. Sending a sleep command when an error seems to resolve the issue. An unrecoverable error before before retries have being exhausted seems to not have being covered with a sleep command previously