### PR TITLE
Tighten serialport spec to ^4.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 i2c-linux = "0"
-serialport = { version = "4", default-features = false }
+serialport = { version = "4.9", default-features = false }
 sha2 = "0"
 bytes = "1"
 bitfield = "0"


### PR DESCRIPTION
## Summary
- Bumps the `serialport` dependency from `"4"` to `"4.9"` so fresh resolution lands on the latest non-yanked 4.x baseline (4.7.0-4.7.2 are yanked).
- No source changes required; verified with `cargo build`, `cargo fmt --check`, and `cargo clippy -- -Dclippy::all` against `serialport 4.9.0`.