### PR TITLE
Modernize CI workflow and gitignore .DS_Store

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,29 +7,37 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTFLAGS: "-D warnings"
+  RUSTUP_MAX_RETRIES: 10
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Setup | Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup | Rust
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          default: true
-          override: true
           components: clippy, rustfmt
 
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.5.0
-        with:
-          access_token: ${{ github.token }}
+      - name: Setup | Cache
+        uses: Swatinem/rust-cache@v2
 
-      - name: Check formatting
-        run: cargo fmt  -- --check
+      - name: Build | Hygiene
+        run: |
+          cargo fmt -- --check
+          cargo clippy -- -D clippy::all
 
-      - name: Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: -- -Dclippy::all
+      - name: Build | Compile
+        run: cargo build

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 .envrc
 Cargo.lock
+.DS_Store


### PR DESCRIPTION
## Summary
- Replaces deprecated actions (`actions/checkout@v2`, `actions-rs/toolchain@v1`, `actions-rs/clippy-check@v1`, `styfle/cancel-workflow-action`) with maintained equivalents: `checkout@v4`, `dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2`, and a native `concurrency` block.
- Adds `RUSTFLAGS=-D warnings` so warnings fail CI, and runs `cargo build` in addition to fmt/clippy.
- Gitignores `.DS_Store` so it stops blocking `cargo release` runs.